### PR TITLE
src/sync: Add Client::publish_success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1]
+### Added
+- Add `Client::publish_success` to signal instance success to daemon and sync service. See [PR 5].
+
+[PR 5]: https://github.com/testground/sdk-rust/pull/5
 
 ## [0.1.0] - 2022-01-24
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-soketto = "0.7.1"
 async-std = { version = "1.10", features = [ "attributes" ] }
+log = "0.4"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
+soketto = "0.7.1"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 name = "testground"
 repository = "https://github.com/testground/sdk-rust/"
-version = "0.1.0"
+version = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -57,6 +57,7 @@ impl Client {
                 state: contextualized_state,
             }),
             barrier: None,
+            publish: None,
         };
 
         self.send(request).await?;
@@ -83,6 +84,7 @@ impl Client {
         let request = Request {
             id: id.clone(),
             signal_entry: None,
+            publish: None,
             barrier: Some(BarrierRequest {
                 state: contextualized_state,
                 target,
@@ -98,6 +100,36 @@ impl Client {
             return Err(BarrierError::Remote(resp.error));
         }
         Ok(())
+    }
+
+    pub async fn publish_success(&mut self) -> Result<u64, PublishSuccessError> {
+        let id = self.next_id().to_string();
+
+        let request = Request {
+            id: id.clone(),
+            signal_entry: None,
+            barrier: None,
+            publish: Some(PublishRequest {
+                topic: topic(),
+                payload: Event {
+                    success_event: SuccessEvent {
+                        group: std::env::var("TEST_GROUP_ID").unwrap(),
+                    },
+                },
+            }),
+        };
+
+        self.send(request).await?;
+        let resp = self.receive().await?;
+        if resp.id != id {
+            return Err(PublishSuccessError::UnexpectedId(resp.id));
+        }
+        if !resp.error.is_empty() {
+            return Err(PublishSuccessError::Remote(resp.error));
+        }
+        resp.publish
+            .ok_or(PublishSuccessError::ExpectedPublishInResponse)
+            .map(|resp| resp.seq)
     }
 
     fn next_id(&mut self) -> u64 {
@@ -120,14 +152,21 @@ impl Client {
     }
 }
 
-fn contextualize_state(state: String) -> String {
+fn context_from_env() -> String {
     format!(
-        "run:{}:plan:{}:case:{}:states:{}",
+        "run:{}:plan:{}:case:{}",
         std::env::var("TEST_RUN").unwrap(),
         std::env::var("TEST_PLAN").unwrap(),
         std::env::var("TEST_CASE").unwrap(),
-        state
     )
+}
+
+fn contextualize_state(state: String) -> String {
+    format!("{}:states:{}", context_from_env(), state,)
+}
+
+fn topic() -> String {
+    format!("{}:run_events", context_from_env(),)
 }
 
 #[derive(Error, Debug)]
@@ -157,6 +196,20 @@ pub enum BarrierError {
 }
 
 #[derive(Error, Debug)]
+pub enum PublishSuccessError {
+    #[error("Remote returned error {0}.")]
+    Remote(String),
+    #[error("Remote returned response with unexpected ID {0}.")]
+    UnexpectedId(String),
+    #[error("Expected remote to return signal entry in response.")]
+    ExpectedPublishInResponse,
+    #[error("Error sending request {0}")]
+    Send(#[from] SendError),
+    #[error("Error receiving response: {0}")]
+    Receive(#[from] ReceiveError),
+}
+
+#[derive(Error, Debug)]
 pub enum SendError {
     #[error("Soketto: {0}")]
     Soketto(#[from] soketto::connection::Error),
@@ -179,6 +232,7 @@ struct Request {
     id: String,
     signal_entry: Option<SignalEntryRequest>,
     barrier: Option<BarrierRequest>,
+    publish: Option<PublishRequest>,
 }
 
 #[derive(Serialize)]
@@ -192,14 +246,36 @@ struct BarrierRequest {
     target: u64,
 }
 
+#[derive(Serialize)]
+struct PublishRequest {
+    topic: String,
+    payload: Event,
+}
+
+#[derive(Serialize)]
+struct Event {
+    success_event: SuccessEvent,
+}
+
+#[derive(Serialize)]
+struct SuccessEvent {
+    group: String,
+}
+
 #[derive(Deserialize, Debug)]
 struct Response {
     id: String,
     signal_entry: Option<SignalEntryResponse>,
     error: String,
+    publish: Option<PublishResponse>,
 }
 
 #[derive(Deserialize, Debug)]
 struct SignalEntryResponse {
+    seq: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct PublishResponse {
     seq: u64,
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -139,6 +139,7 @@ impl Client {
     }
 
     async fn send(&mut self, req: Request) -> Result<(), SendError> {
+        log::debug!("Sending request: {:?}", req);
         self.sender.send_text(serde_json::to_string(&req)?).await?;
         self.sender.flush().await?;
         Ok(())
@@ -148,6 +149,7 @@ impl Client {
         let mut data = Vec::new();
         self.receiver.receive_data(&mut data).await?;
         let resp = serde_json::from_str(&String::from_utf8(data)?)?;
+        log::debug!("Received response: {:?}", resp);
         Ok(resp)
     }
 }
@@ -201,7 +203,7 @@ pub enum PublishSuccessError {
     Remote(String),
     #[error("Remote returned response with unexpected ID {0}.")]
     UnexpectedId(String),
-    #[error("Expected remote to return signal entry in response.")]
+    #[error("Expected remote to return publish entry in response.")]
     ExpectedPublishInResponse,
     #[error("Error sending request {0}")]
     Send(#[from] SendError),
@@ -227,7 +229,7 @@ pub enum ReceiveError {
     FromUtf8(#[from] std::string::FromUtf8Error),
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct Request {
     id: String,
     signal_entry: Option<SignalEntryRequest>,
@@ -235,29 +237,29 @@ struct Request {
     publish: Option<PublishRequest>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct SignalEntryRequest {
     state: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct BarrierRequest {
     state: String,
     target: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct PublishRequest {
     topic: String,
     payload: Event,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct Event {
     success_event: SuccessEvent,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct SuccessEvent {
     group: String,
 }


### PR DESCRIPTION
Enables test instances to signal success both via a publish to the sync service and to Testground daemon via stdout.