### PR TITLE
*: Provide simple example to be run by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,46 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  testground:
+    name: Testground runs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          path: sdk-rust
+
+      - name: Checkout testground
+        uses: actions/checkout@v2
+        with:
+          path: testground
+          repository: testground/testground
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16.x"
+
+      - name: Install testground
+        run: make install
+        working-directory: testground
+
+      - name: Run testground daemon
+        run: testground daemon &
+
+      - name: Import testground plans
+        run: testground plan import --from sdk-rust
+
+      - name: Run testground plan (sdk-rust)
+        run: |
+          testground run single \
+            --plan=sdk-rust \
+            --testcase=example \
+            --builder=docker:generic \
+            --runner=local:docker \
+            --instances=1 \
+            --wait

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.57-bullseye as builder
+WORKDIR /usr/src/sdk-rust
+COPY . .
+RUN cd plan && cargo build --example example
+
+FROM debian:bullseye-slim
+COPY --from=builder /usr/src/sdk-rust/plan/target/debug/examples/example /usr/local/bin/example
+EXPOSE 6060
+ENTRYPOINT [ "example"]

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,8 @@
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut sync_client = testground::sync::Client::new().await?;
+
+    sync_client.publish_success().await?;
+
+    Ok(())
+}

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,0 +1,15 @@
+name = "sdk-rust"
+
+[defaults]
+builder = "docker:generic"
+runner = "local:docker"
+
+[builders."docker:generic"]
+enabled = true
+
+[runners."local:docker"]
+enabled = true
+
+[[testcases]]
+name = "example"
+instances = { min = 1, max = 1, default = 1 }


### PR DESCRIPTION
This commits adds a simple example (`examples/example.rs`) as well as
a Testground manifest (`./manifest.toml`) to run a single Testground
instance, using sdk-rust, connecting to the sync service and signaling
success.

Can be run via:

```
testground plan import --from sdk-rust

testground run single \
         --plan=sdk-rust \
         --testcase=example \
         --builder=docker:generic \
         --runner=local:docker \
         --instances=1 \
         --wait
```