### PR TITLE
src/: Consume Client on success/failure/crash and shutdown background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add  PubSub, Network Shaping & Metrics. See [PR 6].
 
+### Change
+- Take ownership of `Client` when signaling success / failure. See [PR 7].
+
 [PR 6]: https://github.com/testground/sdk-rust/pull/6
+[PR 7]: https://github.com/testground/sdk-rust/pull/7
 
 ## [0.1.1]
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "3", default-features = false, features = ["std", "derive", "
 futures = { version = "0.3", default-features = false, features = [] }
 influxdb = { version = "0.5", default-features = false, features = ["reqwest", "serde", "serde_json", "derive"] }
 ipnetwork = { version = "0.18.0", default-features = false, features = ["serde"] }
+log = "0.4"
 soketto = { version = "0.7", default-features = false, features = [] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }

--- a/src/background.rs
+++ b/src/background.rs
@@ -214,7 +214,7 @@ impl BackgroundTask {
                 cmd = self.client_rx.recv() => match cmd {
                     Some(cmd) => self.command(cmd).await,
                     None => {
-                        eprintln!("Client command receiver dropped");
+                        log::debug!("Client command sender dropped. Background task shutting down.");
                         return;
                     },
                 },

--- a/src/client.rs
+++ b/src/client.rs
@@ -194,14 +194,14 @@ impl Client {
             event: EventType::Message { message },
         };
 
-        //TODO implment logger similar to go-sdk
+        //TODO implement logger similar to go-sdk
 
         let json_event = serde_json::to_string(&event).expect("Event Serialization");
 
         println!("{}", json_event);
     }
 
-    pub async fn record_success(&self) -> Result<(), Error> {
+    pub async fn record_success(self) -> Result<(), Error> {
         let (sender, receiver) = oneshot::channel();
 
         let cmd = Command::SignalSuccess { sender };
@@ -213,7 +213,7 @@ impl Client {
         Ok(())
     }
 
-    pub async fn record_failure(&self, error: impl Into<Cow<'static, str>>) -> Result<(), Error> {
+    pub async fn record_failure(self, error: impl Into<Cow<'static, str>>) -> Result<(), Error> {
         let error = error.into().into_owned();
 
         let (sender, receiver) = oneshot::channel();
@@ -228,7 +228,7 @@ impl Client {
     }
 
     pub async fn record_crash(
-        &self,
+        self,
         error: impl Into<Cow<'static, str>>,
         stacktrace: impl Into<Cow<'static, str>>,
     ) -> Result<(), Error> {


### PR DESCRIPTION
Consume the `Client` on `record_{crash,failure,success}`, thus enforcing
the library user to e.g. not signal success twice.

As the background task accept dropping the client command sender as a
valid signal to shutdown.