### PR TITLE
src/errors: Expose errors module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod background;
 pub mod client;
-mod errors;
+pub mod errors;
 mod events;
 pub mod network_conf;
 mod params;


### PR DESCRIPTION
Exposed `errors` module so that test plans can use the `Error` enum.