### PR TITLE
Re-export public dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,6 @@ mod requests;
 mod responses;
 
 pub use params::RunParameters;
+
+// Re-export public dependencies.
+pub use influxdb::{Timestamp, WriteQuery};


### PR DESCRIPTION
`Client::record_metric`, a public API, depends on the type in `influxdb` crate.

This PR added re-exporting so that sdk users record their metrics without adding `influxdb` crate to their dependencies.

```rust
    use testground::{Timestamp, WriteQuery};

    let write_query = WriteQuery::new(Timestamp::Seconds(0), "measurement")
        .add_field("bytes_recv", metrics.bytes_recv as u64);

    client.record_metric(write_query).await?;
```