### PR TITLE
src/params: Make RunParameters::test_group_instance_count a u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - unreleased
+### Change
+- Make `RunParameters::test_group_instance_count` a `u64` to be consistent with
+  `RunParameters::test_instance_count`. See [PR 26].
+
+[PR 26]: https://github.com/testground/sdk-rust/pull/26
+
 ## [0.3.0]
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 name = "testground"
 repository = "https://github.com/testground/sdk-rust/"
-version = "0.3.0"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -46,7 +46,7 @@ pub struct RunParameters {
     pub test_capture_profiles: String, // TEST_CAPTURE_PROFILES:
 
     #[clap(env)]
-    pub test_group_instance_count: usize, // TEST_GROUP_INSTANCE_COUNT: 1
+    pub test_group_instance_count: u64, // TEST_GROUP_INSTANCE_COUNT: 1
     #[clap(env)]
     pub test_group_id: String, // TEST_GROUP_ID: single
 


### PR DESCRIPTION
To be consistent with `RunParameters::test_instance_count`.

@SionoiS @ackintosh what do you think?