### PR TITLE
src/background: Don't wait for network when no sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - unreleased
+### Change
+- Don't wait for network when no sidecar. See [PR 27].
+
+[PR 27]: https://github.com/testground/sdk-rust/pull/27
+
 ## [0.3.0]
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 name = "testground"
 repository = "https://github.com/testground/sdk-rust/"
-version = "0.3.0"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/background.rs
+++ b/src/background.rs
@@ -274,7 +274,10 @@ impl BackgroundTask {
             }
             Command::WaitNetworkInitializedBarrier { sender } => {
                 if !self.params.test_sidecar {
-                    let _ = sender.send(Err(Error::SideCar));
+                    log::debug!(
+                        "Running in environment without network side car. \
+                        Skipping wait for network."
+                    );
                     return;
                 }
 


### PR DESCRIPTION
sdk-go does not wait for the network sidecar to signal the network being
ready when there is no sidecar.

https://github.com/testground/sdk-go/blob/49c90fa754052018b70c63d87b7f1d37f6080a78/network/client.go#L45-L51

The mental model might be that in these cases, the network is already set up.

For the sake of consistency this commit applies the same to sdk-rust.