### PR TITLE
Hold global and group sequence numbers in `Client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - unreleased
+### Added
+- Add `global_seq` and `group_seq` to `Client`, sequence numbers assigned to test instance by the sync service. See [PR 29]
+
 ### Change
 - Make `RunParameters::test_group_instance_count` a `u64` to be consistent with
   `RunParameters::test_instance_count`. See [PR 26].
@@ -14,8 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   other instances to do the same. Also makes `Client::wait_network_initialized`
   private, as it is included in `Client::new_and_init` now. See [PR 25].
 
+- Move `RunParameters` to a field on `Client`. See [PR 29].
+
 [PR 26]: https://github.com/testground/sdk-rust/pull/26
 [PR 26]: https://github.com/testground/sdk-rust/pull/25
+[PR 29]: https://github.com/testground/sdk-rust/pull/29
 
 ## [0.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   private, as it is included in `Client::new_and_init` now. See [PR 25].
 
 [PR 26]: https://github.com/testground/sdk-rust/pull/26
-[PR 26]: https://github.com/testground/sdk-rust/pull/25
+[PR 25]: https://github.com/testground/sdk-rust/pull/25
 [PR 27]: https://github.com/testground/sdk-rust/pull/27
 [PR 29]: https://github.com/testground/sdk-rust/pull/29
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -5,7 +5,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.record_message(format!(
         "{}, sdk-rust!",
         client
-            .run_parameters
+            .run_parameters()
             .test_instance_params
             .get("greeting")
             .unwrap()

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,10 +1,14 @@
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (client, run_parameters) = testground::client::Client::new_and_init().await?;
+    let client = testground::client::Client::new_and_init().await?;
 
     client.record_message(format!(
         "{}, sdk-rust!",
-        run_parameters.test_instance_params.get("greeting").unwrap()
+        client
+            .run_parameters
+            .test_instance_params
+            .get("greeting")
+            .unwrap()
     ));
 
     client.record_success().await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,11 +26,11 @@ const BACKGROUND_SENDER: &str = "Background Sender";
 pub struct Client {
     cmd_tx: Sender<Command>,
     /// The runtime parameters for this test.
-    pub run_parameters: RunParameters,
+    run_parameters: RunParameters,
     /// A global sequence number assigned to this test instance by the sync service.
-    pub global_seq: u64,
+    global_seq: u64,
     /// A group-scoped sequence number assigned to this test instance by the sync service.
-    pub group_seq: u64,
+    group_seq: u64,
 }
 
 impl Client {
@@ -302,5 +302,20 @@ impl Client {
         receiver.await.expect(BACKGROUND_SENDER)?;
 
         Ok(())
+    }
+
+    /// Returns runtime parameters for this test.
+    pub fn run_parameters(&self) -> RunParameters {
+        self.run_parameters.clone()
+    }
+
+    /// Returns a global sequence number assigned to this test instance.
+    pub fn global_seq(&self) -> u64 {
+        self.global_seq
+    }
+
+    /// Returns a group-scoped sequence number assigned to this test instance.
+    pub fn group_seq(&self) -> u64 {
+        self.group_seq
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use ipnetwork::IpNetwork;
 
 #[derive(Parser, Debug, Clone)]
+/// RunParameters encapsulates the runtime parameters for this test.
 pub struct RunParameters {
     #[clap(env)]
     pub test_plan: String, // TEST_PLAN: streaming_test


### PR DESCRIPTION
Ref: https://github.com/ackintosh/discv5-testground/pull/23#discussion_r901196421

- Add `global_seq` and `group_seq` to `Client`, sequence numbers assigned to test instance by the sync service.
- Move `RunParameters` to a field on `Client`.