### PR TITLE
Fix: use json payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           testground healthcheck --runner local:docker --fix;
         shell: bash
 
-      - name: Run testground plan (sdk-rust)
+      - name: Run testground plan (case=example)
         run: |
           testground run single       \
             --plan=sdk-rust           \
@@ -124,7 +124,19 @@ jobs:
             --instances=1             \
             --wait                    \
             --collect                 \
-            --collect-file ./result.tgz
+            --collect-file ./result_example.tgz
+
+      - name: Run testground plan (case=publish-subscribe)
+        run: |
+          testground run single          \
+            --plan=sdk-rust              \
+            --testcase=publish-subscribe \
+            --builder=docker:generic     \
+            --runner=local:docker        \
+            --instances=2                \
+            --wait                       \
+            --collect                    \
+            --collect-file ./result_publish_subscribe.tgz
 
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
@@ -132,4 +144,4 @@ jobs:
           name: testground-output
           path: |
             testground/daemon.*
-            result.tgz
+            result*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   other instances to do the same. Also makes `Client::wait_network_initialized`
   private, as it is included in `Client::new_and_init` now. See [PR 25].
 
+- Use a JSON Payload instead of string in `publish` and `subscribe`. See [PR 34].
+
 [PR 26]: https://github.com/testground/sdk-rust/pull/26
 [PR 25]: https://github.com/testground/sdk-rust/pull/25
 [PR 27]: https://github.com/testground/sdk-rust/pull/27
 [PR 29]: https://github.com/testground/sdk-rust/pull/29
+[PR 34]: https://github.com/testground/sdk-rust/pull/34
 
 ## [0.3.0]
 ### Added

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = testground::client::Client::new_and_init().await?;
@@ -11,9 +13,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap()
     ));
 
-    client
-        .publish("demonstration", serde_json::json!({"foo": "bar"}))
-        .await?;
+    let json = serde_json::json!({"foo": "bar"});
+
+    client.publish("demonstration", Cow::Owned(json)).await?;
 
     client.record_success().await?;
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,9 +1,19 @@
 use std::borrow::Cow;
 
+use tokio_stream::StreamExt;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = testground::client::Client::new_and_init().await?;
 
+    match client.run_parameters().test_case.as_str() {
+        "example" => example(client).await,
+        "publish-subscribe" => publish_subscribe(client).await,
+        _ => panic!("Unknown test case: {}", client.run_parameters().test_case),
+    }
+}
+
+async fn example(client: testground::client::Client) -> Result<(), Box<dyn std::error::Error>> {
     client.record_message(format!(
         "{}, sdk-rust!",
         client
@@ -14,10 +24,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     let json = serde_json::json!({"foo": "bar"});
-
     client.publish("demonstration", Cow::Owned(json)).await?;
-
     client.record_success().await?;
 
+    Ok(())
+}
+
+async fn publish_subscribe(
+    client: testground::client::Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+    client.record_message("running the publish_subscribe test");
+
+    match client.global_seq() {
+        1 => {
+            client.record_message("I am instance 1: acting as the leader");
+
+            let json = serde_json::json!({"foo": "bar"});
+            client.publish("demonstration", Cow::Owned(json)).await?;
+            client.record_success().await?;
+        }
+        _ => {
+            client.record_message(format!(
+                "I am instance {}: acting as a follower",
+                client.global_seq()
+            ));
+
+            let payload = client
+                .subscribe("demonstration")
+                .await
+                .take(1)
+                .map(|x| x.unwrap())
+                .next()
+                .await
+                .unwrap();
+
+            client.record_message(format!("I received the payload: {}", payload));
+
+            if payload["foo"].as_str() == Some("bar") {
+                client.record_success().await?;
+            } else {
+                client
+                    .record_failure(format!("invalid payload: {}", payload))
+                    .await?;
+            }
+        }
+    }
     Ok(())
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -23,8 +23,6 @@ async fn example(client: testground::client::Client) -> Result<(), Box<dyn std::
             .unwrap()
     ));
 
-    let json = serde_json::json!({"foo": "bar"});
-    client.publish("demonstration", Cow::Owned(json)).await?;
     client.record_success().await?;
 
     Ok(())

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -11,6 +11,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap()
     ));
 
+    client
+        .publish("demonstration", serde_json::json!({"foo": "bar"}))
+        .await?;
+
     client.record_success().await?;
 
     Ok(())

--- a/manifest.toml
+++ b/manifest.toml
@@ -16,3 +16,7 @@ instances = { min = 1, max = 1, default = 1 }
 
   [testcases.params]
   greeting = { type = "string", desc = "greeting", default = "Hello" }
+
+[[testcases]]
+name = "publish-subscribe"
+instances = { min = 2, max = 10, default = 2 }

--- a/src/background.rs
+++ b/src/background.rs
@@ -233,7 +233,7 @@ impl BackgroundTask {
             } => {
                 let topic = self.contextualize_topic(&topic);
 
-                self.publish(id, topic, PayloadType::JSON(message), sender)
+                self.publish(id, topic, PayloadType::Json(message), sender)
                     .await
             }
             Command::Subscribe { topic, stream } => {

--- a/src/background.rs
+++ b/src/background.rs
@@ -28,7 +28,7 @@ pub enum Command {
     },
     Subscribe {
         topic: String,
-        stream: mpsc::Sender<Result<String, Error>>,
+        stream: mpsc::Sender<Result<serde_json::Value, Error>>,
     },
 
     SignalEntry {
@@ -89,7 +89,7 @@ enum PendingRequest {
         sender: oneshot::Sender<Result<(), Error>>,
     },
     Subscribe {
-        stream: mpsc::Sender<Result<String, Error>>,
+        stream: mpsc::Sender<Result<serde_json::Value, Error>>,
     },
 }
 
@@ -406,7 +406,7 @@ impl BackgroundTask {
         &mut self,
         id: u64,
         topic: String,
-        stream: mpsc::Sender<Result<String, Error>>,
+        stream: mpsc::Sender<Result<serde_json::Value, Error>>,
     ) {
         let request = Request {
             id: id.to_string(),

--- a/src/background.rs
+++ b/src/background.rs
@@ -23,7 +23,7 @@ const WEBSOCKET_RECEIVER: &str = "Websocket Receiver";
 pub enum Command {
     Publish {
         topic: String,
-        message: String,
+        message: serde_json::Value,
         sender: oneshot::Sender<Result<u64, Error>>,
     },
     Subscribe {
@@ -233,7 +233,7 @@ impl BackgroundTask {
             } => {
                 let topic = self.contextualize_topic(&topic);
 
-                self.publish(id, topic, PayloadType::String(message), sender)
+                self.publish(id, topic, PayloadType::JSON(message), sender)
                     .await
             }
             Command::Subscribe { topic, stream } => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -87,7 +87,7 @@ impl Client {
     pub async fn publish(
         &self,
         topic: impl Into<Cow<'static, str>>,
-        message: impl Into<Cow<'static, str>>,
+        message: impl Into<Cow<'static, serde_json::Value>>,
     ) -> Result<u64, Error> {
         let (sender, receiver) = oneshot::channel();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -106,7 +106,7 @@ impl Client {
     pub async fn subscribe(
         &self,
         topic: impl Into<Cow<'static, str>>,
-    ) -> impl Stream<Item = Result<String, Error>> {
+    ) -> impl Stream<Item = Result<serde_json::Value, Error>> {
         let (stream, out) = mpsc::channel(1);
 
         let cmd = Command::Subscribe {

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -17,7 +17,7 @@ pub struct Request {
 pub enum PayloadType {
     Event(EventType),
 
-    String(String),
+    JSON(serde_json::Value),
 
     Config(NetworkConfiguration),
 }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -17,7 +17,7 @@ pub struct Request {
 pub enum PayloadType {
     Event(EventType),
 
-    JSON(serde_json::Value),
+    Json(serde_json::Value),
 
     Config(NetworkConfiguration),
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -18,8 +18,7 @@ pub struct RawResponse {
     #[serde(with = "string_empty_as_none")]
     pub error: Option<String>,
 
-    #[serde(with = "string_empty_as_none")]
-    pub subscribe: Option<String>,
+    pub subscribe: Option<serde_json::Value>,
 
     pub signal_entry: Option<SignalEntry>,
 
@@ -30,7 +29,7 @@ pub struct RawResponse {
 pub enum ResponseType {
     SignalEntry { seq: u64 },
     Publish { seq: u64 },
-    Subscribe(String),
+    Subscribe(serde_json::Value),
     Error(String),
     Barrier,
 }
@@ -58,11 +57,7 @@ impl From<RawResponse> for Response {
                 let error = serde_json::from_str(&error).expect("JSON Deserialization");
                 ResponseType::Error(error)
             }
-            (None, Some(msg), None, None) => {
-                //Hack to remove extra escape characters
-                let msg = serde_json::from_str(&msg).expect("JSON Deserialization");
-                ResponseType::Subscribe(msg)
-            }
+            (None, Some(msg), None, None) => ResponseType::Subscribe(msg),
             (None, None, Some(signal), None) => ResponseType::SignalEntry { seq: signal.seq },
             (None, None, None, Some(publish)) => ResponseType::Publish { seq: publish.seq },
             (error, subscribe, signal_entry, publish) => {
@@ -89,7 +84,8 @@ mod tests {
 
     #[test]
     fn serde_test() {
-        let raw_response = "{\"id\":\"0\",\"error\":\"\",\"subscribe\":\"\",\"publish\":{\"seq\":1},\"signal_entry\":null}";
+        let raw_response =
+            "{\"id\":\"0\",\"error\":\"\",\"publish\":{\"seq\":1},\"signal_entry\":null}";
 
         let response: RawResponse = serde_json::from_str(raw_response).unwrap();
 
@@ -99,6 +95,25 @@ mod tests {
             Response {
                 id: "0".to_owned(),
                 response: ResponseType::Publish { seq: 1 }
+            },
+            response
+        );
+    }
+    #[test]
+    fn serde_test_complex_subscribe() {
+        let raw_response = "{\"id\":\"1\",\"error\":\"\",\"subscribe\":{\"Addrs\":[\"/ip4/16.3.0.3/tcp/45369\"],\"ID\":\"QmbSLMEMackm7vHiUGMB2EFAPbzeJNpeB9yTpzYKoojDWc\"}}";
+
+        let response: RawResponse = serde_json::from_str(raw_response).unwrap();
+
+        let response: Response = response.into();
+
+        assert_eq!(
+            Response {
+                id: "1".to_owned(),
+                response: ResponseType::Subscribe(serde_json::json!({
+                    "Addrs": ["/ip4/16.3.0.3/tcp/45369"],
+                    "ID": "QmbSLMEMackm7vHiUGMB2EFAPbzeJNpeB9yTpzYKoojDWc"
+                }))
             },
             response
         );

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -59,7 +59,7 @@ impl From<RawResponse> for Response {
                 ResponseType::Error(error)
             }
             (None, Some(msg), None, None) => {
-                // the Subscribe payload is a json encoded string, so we need to deserialize it
+                // The Subscribe payload is a json encoded string, so we need to deserialize it.
                 let payload = serde_json::from_str(&msg).expect("JSON Deserialization");
                 ResponseType::Subscribe(payload)
             }


### PR DESCRIPTION
Fixes #33,

- [x] Uses a json payload for publish / subscribes,
- [x] introduce `publish-subscribe` example, which demonstrate leader / follower pattern with JSON payloads.