### PR TITLE
src/client: Make subscribe stream capacity explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use a JSON Payload instead of string in `publish` and `subscribe`. See [PR 34].
 
+- Make footgun `Client::subscribe` explicit, requiring user to provide a
+  capacity. See [PR 36].
+
 [PR 26]: https://github.com/testground/sdk-rust/pull/26
 [PR 25]: https://github.com/testground/sdk-rust/pull/25
 [PR 27]: https://github.com/testground/sdk-rust/pull/27
 [PR 29]: https://github.com/testground/sdk-rust/pull/29
 [PR 34]: https://github.com/testground/sdk-rust/pull/34
+[PR 36]: https://github.com/testground/sdk-rust/pull/36
 
 ## [0.3.0]
 ### Added

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -48,7 +48,7 @@ async fn publish_subscribe(
             ));
 
             let payload = client
-                .subscribe("demonstration")
+                .subscribe("demonstration", usize::MAX)
                 .await
                 .take(1)
                 .map(|x| x.unwrap())

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -48,7 +48,7 @@ async fn publish_subscribe(
             ));
 
             let payload = client
-                .subscribe("demonstration", usize::MAX)
+                .subscribe("demonstration", u16::MAX.into())
                 .await
                 .take(1)
                 .map(|x| x.unwrap())

--- a/src/client.rs
+++ b/src/client.rs
@@ -114,7 +114,7 @@ impl Client {
     /// ```no_run
     /// # use testground::client::Client;
     /// # let client: Client = todo!();
-    /// client.subscribe("my_topic", usize::MAX);
+    /// client.subscribe("my_topic", u16::MAX.into());
     /// ```
     pub async fn subscribe(
         &self,

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,12 +102,26 @@ impl Client {
         receiver.await.expect(BACKGROUND_SENDER)
     }
 
-    /// ```subscribe``` subscribes to a topic, consuming ordered, elements from index 0.
+    /// ```subscribe``` subscribes to a topic, consuming ordered, elements from
+    /// index 0.
+    ///
+    /// Note that once the capacity of the returned [`Stream`] is reached, the
+    /// background task blocks and thus all work related to the [`Client`] will
+    /// pause until elements from the [`Stream`] are consumed and thus capacity
+    /// is freed. Callers of [`Client::subscribe`] should either set a high
+    /// capacity, continuously read from the returned [`Stream`] or drop it.
+    ///
+    /// ```no_run
+    /// # use testground::client::Client;
+    /// # let client: Client = todo!();
+    /// client.subscribe("my_topic", usize::MAX);
+    /// ```
     pub async fn subscribe(
         &self,
         topic: impl Into<Cow<'static, str>>,
+        capacity: usize,
     ) -> impl Stream<Item = Result<serde_json::Value, Error>> {
-        let (stream, out) = mpsc::channel(1);
+        let (stream, out) = mpsc::channel(capacity);
 
         let cmd = Command::Subscribe {
             topic: topic.into().into_owned(),


### PR DESCRIPTION
Makes footgun on `Client::subscribe` explicit.

> Note that once the capacity of the returned [`Stream`] is reached, the
> background task blocks and thus all work related to the [`Client`] will
> pause until elements from the [`Stream`] are consumed and thus capacity
> is freed. Callers of [`Client::subscribe`] should either set a high
> capacity, continuously read from the returned [`Stream`] or drop it.

This has probably cost me 1h to debug on https://github.com/libp2p/test-plans/pull/26. What do folks think?