### PR TITLE
src/: Derive `Eq` on structs

### DIFF
--- a/src/network_conf.rs
+++ b/src/network_conf.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum FilterAction {
     Accept = 0,

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -27,7 +27,7 @@ pub struct RawResponse {
     pub publish: Option<Publish>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ResponseType {
     SignalEntry { seq: u64 },
     Publish { seq: u64 },
@@ -36,7 +36,7 @@ pub enum ResponseType {
     Barrier,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Response {
     pub id: String,
     pub response: ResponseType,


### PR DESCRIPTION
Clippy is complaining with the below.

```
 error: you are deriving `PartialEq` and can implement `Eq`
Error:  --> src/network_conf.rs:8:44
  |
8 | #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
  |                                            ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
  |
  = note: `-D clippy::derive-partial-eq-without-eq` implied by `-D warnings`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
```