### PR TITLE
Make `RunParameters::test_start_time` a `DateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - unreleased
 ### Change
-- Make `RunParameters::test_start_time` from `String` to `DateTime` for ease of use. See [PR 41].
+- Change `RunParameters::test_start_time` from `String` to `DateTime` for ease of use. See [PR 41].
 
 [PR 41]: https://github.com/testground/sdk-rust/pull/41
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - unreleased
+### Change
+- Make `RunParameters::test_start_time` from `String` to `DateTime` for ease of use. See [PR 41].
+
+[PR 41]: https://github.com/testground/sdk-rust/pull/41
+
 ## [0.4.0]
 ### Added
 - Add `global_seq` and `group_seq` to `Client`, sequence numbers assigned to test instance by the sync service. See [PR 29]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4"
 clap = { version = "3", default-features = false, features = ["std", "derive", "env"] }
 futures = { version = "0.3", default-features = false, features = [] }
 if-addrs = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "3", default-features = false, features = ["std", "derive", "env"] }
 futures = { version = "0.3", default-features = false, features = [] }
 if-addrs = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 name = "testground"
 repository = "https://github.com/testground/sdk-rust/"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 clap = { version = "3", default-features = false, features = ["std", "derive", "env"] }
 futures = { version = "0.3", default-features = false, features = [] }
 if-addrs = "0.7.0"

--- a/src/params.rs
+++ b/src/params.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
 use std::path::PathBuf;
+use chrono::{DateTime, FixedOffset};
 
 use ipnetwork::IpNetwork;
 
@@ -41,7 +42,7 @@ pub struct RunParameters {
     #[clap(env)]
     pub test_subnet: IpNetwork, // TEST_SUBNET: 16.0.0.0/16
     #[clap(env)]
-    pub test_start_time: String, // TEST_START_TIME: 2022-01-12T15:48:07-05:00
+    pub test_start_time: DateTime<FixedOffset>, // TEST_START_TIME: 2022-01-12T15:48:07-05:00
 
     #[clap(env)]
     pub test_capture_profiles: String, // TEST_CAPTURE_PROFILES:

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
-use std::path::PathBuf;
 use chrono::{DateTime, FixedOffset};
+use std::path::PathBuf;
 
 use ipnetwork::IpNetwork;
 


### PR DESCRIPTION
Changed `RunParameters::test_start_time` from String to DateTime for ease of use. 🙂 