### PR TITLE
Dockerfile: Specify files to be copied to avoid unnecessary compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,12 @@ RUN echo "fn main() { println!(\"If you see this message, you may want to clean 
 COPY ./plan/Cargo.* ./plan/
 RUN cd ./plan/ && cargo build
 
-COPY . .
+# Coping each files only needed instead of doing `COPY . .` (all of them) in order to avoid unnecessary compiling.
+# (e.g. because of modifiying `manifest.toml`.)
+# NOTE: `.dockerignore` is not effective because the build context is not this directory on the test run.
+# See https://docs.testground.ai/builder-library/docker-generic#usage
+COPY ./plan/src ./plan/src
+COPY ./plan/examples ./plan/examples
 
 # This is in order to make sure `main.rs`s mtime timestamp is updated to avoid the dummy `main`
 # remaining in the release binary.


### PR DESCRIPTION
This makes us avoid unnecessary compiling e.g. because of modifiying `manifest.toml`. 🙂 