### PR TITLE
Write events to run.out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.5.0] - unreleased
+### Added
+- Write events to `run.out`. See [PR 45].
+
 ### Change
 - Change `RunParameters::test_start_time` from `String` to `DateTime` for ease of use. See [PR 41].
 
 [PR 41]: https://github.com/testground/sdk-rust/pull/41
+[PR 45]: https://github.com/testground/sdk-rust/pull/45
 
 ## [0.4.0]
 ### Added

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures::stream::StreamExt;
 use influxdb::{Client, WriteQuery};
@@ -377,17 +376,7 @@ impl BackgroundTask {
         if let PayloadType::Event(ref event) = payload {
             // The Testground daemon determines the success or failure of a test
             // instance by parsing stdout for runtime events.
-            println!(
-                "{}",
-                serde_json::to_string(&LogLine {
-                    ts: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_nanos(),
-                    event,
-                })
-                .unwrap(),
-            );
+            println!("{}", serde_json::to_string(&LogLine::new(event)).unwrap());
         }
 
         let request = Request {

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,7 +51,7 @@ impl Client {
             .test_outputs_path
             .to_str()
             .map(|path_str| {
-                if path_str == "" {
+                if path_str.is_empty() {
                     None
                 } else {
                     let mut path = PathBuf::from(path_str);
@@ -86,7 +86,7 @@ impl Client {
             // Note that the sdk-go only signals, but not waits.
             .signal_and_wait(
                 format!("initialized_group_{}", client.run_parameters.test_group_id),
-                client.run_parameters.test_group_instance_count as u64,
+                client.run_parameters.test_group_instance_count,
             )
             .await?;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use serde::Serialize;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Serialize, Debug)]
 pub struct Event {
@@ -11,6 +12,18 @@ pub struct Event {
 pub struct LogLine<'a> {
     pub ts: u128,
     pub event: &'a EventType,
+}
+
+impl LogLine<'_> {
+    pub fn new(event: &EventType) -> LogLine {
+        LogLine {
+            ts: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            event,
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]


### PR DESCRIPTION
This PR is related to  https://github.com/testground/sdk-rust/issues/30.

Only logging to `run.out` has been implemented in this PR.

---

I have checked the output.

record_success: 
```json
{"ts":1674342760265576046,"event":{"message_event":{"message":"claimed sequence numbers; global=1, group(single)=1"}}}
{"ts":1674342760377800046,"event":{"message_event":{"message":"Hello, sdk-rust!"}}}
{"ts":1674342760679254171,"event":{"success_event":{"group":"single"}}}
```

record_failure:
```json
{"ts":1674344428810174513,"event":{"message_event":{"message":"claimed sequence numbers; global=1, group(single)=1"}}}
{"ts":1674344428814512055,"event":{"message_event":{"message":"Hello, sdk-rust!"}}}
{"ts":1674344428817991013,"event":{"failure_event":{"group":"single","error":"error"}}}
```

record_crash:
```json
{"ts":1674344518163850263,"event":{"message_event":{"message":"claimed sequence numbers; global=1, group(single)=1"}}}
{"ts":1674344518165354596,"event":{"message_event":{"message":"Hello, sdk-rust!"}}}
{"ts":1674344518208433013,"event":{"crash_event":{"groups":"single","error":"error","stacktrace":"stacktrace"}}}
```