### PR TITLE
Fix clippy error

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -464,7 +464,7 @@ impl BackgroundTask {
                 let _ = sender.send(Err(Error::SyncService(error)));
             }
             (PendingRequest::Subscribe { stream }, ResponseType::Error(error)) => {
-                let _ = stream.send(Err(Error::SyncService(error)));
+                let _ = stream.send(Err(Error::SyncService(error))).await;
             }
             (PendingRequest::Subscribe { stream }, ResponseType::Subscribe(msg)) => {
                 if stream.send(Ok(msg)).await.is_ok() {

--- a/src/background.rs
+++ b/src/background.rs
@@ -96,7 +96,7 @@ pub struct BackgroundTask {
     websocket_tx: soketto::Sender<Compat<tokio::net::TcpStream>>,
     websocket_rx: futures::stream::BoxStream<'static, Result<Vec<u8>, soketto::connection::Error>>,
 
-    influxdb: influxdb::Client,
+    influxdb: Client,
 
     next_id: u64,
 


### PR DESCRIPTION
Fixed the clippy error on master branch.

https://github.com/testground/sdk-rust/actions/runs/4221055155/jobs/7327921351
> error: non-binding `let` on a future
> = help: consider awaiting the future or dropping explicitly with `std::mem::drop`

I also made a tiny fix while I was at it. 🙂  